### PR TITLE
feat: Silverstripe 6 compatibility (2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Display a video using native HTML5 video
 
 ## Requirements
 
-* Silverstripe ^4.3
-* Silverstripe Elemental ^4.0
+* Silverstripe ^6
+* Silverstripe Elemental ^6
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         {
             "name": "Dynamic",
             "email": "dev@dynamicagency.com",
-            "homepage": "http://www.dynamicagency.com"
+            "homepage": "https://www.dynamicagency.com"
         }
     ],
     "keywords": [
@@ -14,12 +14,18 @@
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
-        "dnadesign/silverstripe-elemental": "^4.0 || ^5.0"
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^2 || ^3.0"
+        "silverstripe/recipe-testing": "^4"
     },
     "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true,
+            "silverstripe/recipe-plugin": true
+        },
         "process-timeout": 600
     },
     "autoload": {
@@ -30,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/framework/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="Default">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 4/5 support. Major version 2.0 requiring Silverstripe 6 only.

## Changes

- **composer.json**: `elemental ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `2.x-dev`
- **phpunit.xml.dist**: Update to PHPUnit 11 format
- **README.md**: Update requirements to SS6

## Version History

| Version | Silverstripe |
|---------|-------------|
| 2.x     | ^6          |
| 1.x     | ^4 / ^5     |
